### PR TITLE
将棋盤と駒の表示機能を実装（Issue #6）

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,12 @@
 import type { Metadata } from "next";
+import { Noto_Serif_JP } from "next/font/google";
 import "./globals.css";
+
+const notoSerifJP = Noto_Serif_JP({
+  subsets: ["latin"],
+  weight: ["400", "700"],
+  variable: "--font-noto-serif-jp",
+});
 
 export const metadata: Metadata = {
   title: "将棋オンライン対戦",
@@ -13,7 +20,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja">
-      <body>{children}</body>
+      <body className={notoSerifJP.variable}>{children}</body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,24 @@
+// 詳細: #6
+'use client';
+
+import { Board } from '@/components/board/Board';
+import { createInitialBoard } from '@/lib/game/initial-state';
+
 export default function Home() {
+  const board = createInitialBoard();
+
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-24">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold mb-4">将棋オンライン対戦</h1>
-        <p className="text-xl text-gray-600 dark:text-gray-400">
-          開発準備完了
+    <main className="flex min-h-screen flex-col items-center justify-center p-4 sm:p-8 md:p-24">
+      <div className="text-center mb-6 sm:mb-8">
+        <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-2 sm:mb-4">
+          将棋オンライン対戦
+        </h1>
+        <p className="text-sm sm:text-base md:text-xl text-gray-600 dark:text-gray-400">
+          盤面表示実装完了（Issue #6）
         </p>
       </div>
+
+      <Board board={board} />
     </main>
   );
 }

--- a/components/board/Board.tsx
+++ b/components/board/Board.tsx
@@ -6,27 +6,87 @@
 'use client';
 
 import React from 'react';
-import type { BoardProps } from '@/types/shogi';
+import type { Board as BoardType } from '@/types/shogi';
+import { Piece } from '@/components/piece/Piece';
 import { BOARD_SIZE } from '@/lib/game/constants';
 
-export function Board({ gameState, onSquareClick }: BoardProps) {
+export type SimpleBoardProps = {
+  board: BoardType;
+};
+
+export function Board({ board }: SimpleBoardProps) {
+  // 筋のラベル（9-1）
+  const getFileLabel = (file: number): string => String(9 - file);
+
+  // 段のラベル（一-九）
+  const getRankLabel = (rank: number): string => {
+    const labels = ['一', '二', '三', '四', '五', '六', '七', '八', '九'];
+    return labels[rank];
+  };
+
   return (
-    <div className="board-container">
-      <div className="board-grid">
-        {/* TODO: マス目の描画（#6で実装） */}
-        {Array.from({ length: BOARD_SIZE }).map((_, rank) => (
-          <div key={rank} className="board-row">
-            {Array.from({ length: BOARD_SIZE }).map((_, file) => (
-              <div
-                key={`${rank}-${file}`}
-                className="board-square"
-                onClick={() => onSquareClick({ rank, file })}
-              >
-                {/* TODO: 駒の表示（#6で実装） */}
-              </div>
-            ))}
+    <div className="flex flex-col items-center gap-2 sm:gap-4">
+      {/* 後手エリア */}
+      <div className="text-sm sm:text-base font-semibold text-gray-700">
+        後手
+      </div>
+
+      {/* 筋のラベル（横軸: 9-1） */}
+      <div className="flex">
+        <div className="w-6 sm:w-8" /> {/* 段ラベル用のスペース */}
+        {Array.from({ length: BOARD_SIZE }).map((_, file) => (
+          <div
+            key={file}
+            className="w-10 h-6 sm:w-12 sm:h-8 flex items-center justify-center text-xs sm:text-sm font-semibold"
+          >
+            {getFileLabel(file)}
           </div>
         ))}
+      </div>
+
+      {/* 盤面本体 */}
+      <div className="flex">
+        {/* 段のラベル（縦軸: 一-九） */}
+        <div className="flex flex-col">
+          {board.map((_, rank) => (
+            <div
+              key={rank}
+              className="w-6 h-10 sm:w-8 sm:h-12 flex items-center justify-center text-xs sm:text-sm font-semibold"
+            >
+              {getRankLabel(rank)}
+            </div>
+          ))}
+        </div>
+
+        {/* 9x9のマス */}
+        <div className="inline-block border-2 border-gray-800 bg-amber-50">
+          {board.map((row, rank) => (
+            <div key={rank} className="flex">
+              {row.map((piece, file) => (
+                <div
+                  key={`${rank}-${file}`}
+                  className="
+                    w-10 h-10
+                    sm:w-12 sm:h-12
+                    border border-gray-400
+                    flex items-center justify-center
+                    bg-amber-50
+                    hover:bg-amber-100
+                    transition-colors
+                    cursor-pointer
+                  "
+                >
+                  {piece && <Piece piece={piece} size="medium" />}
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* 先手エリア */}
+      <div className="text-sm sm:text-base font-semibold text-gray-700">
+        先手
       </div>
     </div>
   );

--- a/components/piece/Piece.tsx
+++ b/components/piece/Piece.tsx
@@ -11,11 +11,32 @@ import { getPieceName } from '@/lib/utils/piece';
 
 export function Piece({ piece, size = 'medium', isDraggable = false }: PieceProps) {
   const pieceName = getPieceName(piece);
-  const className = `piece piece-${piece.owner} piece-${size} ${isDraggable ? 'draggable' : ''}`;
+  const isBlack = piece.owner === 'black';
+
+  // サイズに応じたクラス
+  const sizeClasses = {
+    small: 'text-sm w-6 h-6',
+    medium: 'text-xl w-10 h-10 sm:w-12 sm:h-12',
+    large: 'text-2xl w-14 h-14',
+  };
 
   return (
-    <div className={className} draggable={isDraggable}>
-      <span className="piece-text">{pieceName}</span>
+    <div
+      className={`
+        ${sizeClasses[size]}
+        flex items-center justify-center
+        font-bold
+        select-none
+        ${isBlack ? 'text-gray-900' : 'text-gray-900 rotate-180'}
+        ${isDraggable ? 'cursor-move' : ''}
+      `}
+      style={{
+        // 将棋駒の伝統的なスタイル
+        fontFamily: 'var(--font-noto-serif-jp), "Noto Serif JP", serif',
+      }}
+      draggable={isDraggable}
+    >
+      {pieceName}
     </div>
   );
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "type-check": "tsc --noEmit",
     "test": "jest",
     "test:watch": "jest --watch"
   },


### PR DESCRIPTION
## 概要

Issue #6 の要件を満たす将棋盤と駒の表示機能を実装しました。

## 実装内容

### ✅ 完了した機能

- [x] 9x9のグリッドが表示される
- [x] 座標（1-9、一-九）が表示される
- [x] 初期配置の駒が全て正しく表示される
- [x] レスポンシブデザイン（モバイル・タブレット・デスクトップ）
- [x] TypeScriptの型エラーがない
- [x] ビルドが通る

### 主な変更

1. **components/board/Board.tsx**
   - 9x9グリッドの盤面表示を完全実装
   - 筋（1-9）と段（一-九）のラベル表示
   - レスポンシブ対応（sm/md ブレークポイント）
   - 先手・後手の表示

2. **components/piece/Piece.tsx**
   - 駒の視覚的表示を改善
   - Noto Serif JPフォント使用
   - 後手の駒を180度回転表示
   - サイズ対応（small/medium/large）

3. **app/page.tsx**
   - 初期配置の盤面を表示
   - レスポンシブ対応のレイアウト

4. **app/layout.tsx**
   - Noto Serif JPフォント追加

5. **package.json**
   - `type-check` スクリプト追加

## テスト

- ✅ TypeScript型チェック（`npm run type-check`）
- ✅ ビルド確認（`npm run build`）

## スクリーンショット

（実際の表示はPRマージ後にvercelでプレビュー可能）

## 関連Issue

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)