### PR TITLE
駒を取る機能と持ち駒管理（UIフィードバック強化）

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -56,6 +56,7 @@ function GameContent() {
             <CapturedPieces
               player="white"
               pieces={gameState.captured.white}
+              selectedPiece={gameState.currentTurn === 'white' ? gameState.selectedCapturedPiece : null}
               onPieceClick={handleWhiteCapturedPieceClick}
             />
           </div>
@@ -70,6 +71,7 @@ function GameContent() {
             <CapturedPieces
               player="black"
               pieces={gameState.captured.black}
+              selectedPiece={gameState.currentTurn === 'black' ? gameState.selectedCapturedPiece : null}
               onPieceClick={handleBlackCapturedPieceClick}
             />
           </div>

--- a/components/captured/CapturedPieces.tsx
+++ b/components/captured/CapturedPieces.tsx
@@ -12,7 +12,7 @@ import { PIECE_NAMES_JA } from '@/lib/game/constants';
 // 持ち駒として表示する駒の順序（玉は持ち駒にならない）
 const PIECE_ORDER = ['rook', 'bishop', 'gold', 'silver', 'knight', 'lance', 'pawn'] as const;
 
-export const CapturedPieces = memo(function CapturedPieces({ player, pieces, onPieceClick }: CapturedPiecesProps) {
+export const CapturedPieces = memo(function CapturedPieces({ player, pieces, selectedPiece, onPieceClick }: CapturedPiecesProps) {
   const hasCapturedPieces = PIECE_ORDER.some(pieceType => pieces[pieceType] > 0);
 
   return (
@@ -31,6 +31,9 @@ export const CapturedPieces = memo(function CapturedPieces({ player, pieces, onP
             const count = pieces[pieceType];
             if (count === 0) return null;
 
+            // #11: 選択中の持ち駒をハイライト
+            const isSelected = selectedPiece === pieceType;
+
             return (
               <div
                 key={pieceType}
@@ -39,9 +42,11 @@ export const CapturedPieces = memo(function CapturedPieces({ player, pieces, onP
                   px-3 py-2
                   rounded-md
                   transition-all
-                  ${onPieceClick
-                    ? 'cursor-pointer hover:bg-blue-50 hover:shadow-sm active:bg-blue-100'
-                    : 'bg-gray-50'
+                  ${isSelected
+                    ? 'bg-blue-200 ring-2 ring-blue-400 shadow-lg'
+                    : onPieceClick
+                      ? 'cursor-pointer hover:bg-blue-50 hover:shadow-sm active:bg-blue-100'
+                      : 'bg-gray-50'
                   }
                 `}
                 onClick={() => onPieceClick?.(pieceType)}

--- a/types/shogi.ts
+++ b/types/shogi.ts
@@ -255,6 +255,7 @@ export type PieceProps = {
 export type CapturedPiecesProps = {
   player: Player;
   pieces: PlayerCapturedPieces;
+  selectedPiece?: PieceType | null;  // #11: 選択中の持ち駒
   onPieceClick?: (pieceType: PieceType) => void;
 };
 


### PR DESCRIPTION
## 概要

Issue #11 の完成版：持ち駒選択時のUIフィードバック強化

既存の駒を取る機能と持ち駒管理機能に加えて、ユーザーが持ち駒を選択した際の視覚的フィードバックを実装しました。

## 変更内容

### ✅ 実装済み機能（既存）
- 相手の駒を取る機能（`GameContext.tsx:98-113`）
- 取った駒を持ち駒として管理
- 成駒を元に戻す処理
- 持ち駒表示UI（`CapturedPieces.tsx`）
- 持ち駒クリック時の手番チェック

### ✨ 新規実装
- **持ち駒選択時のUIフィードバック**
  - 選択中の持ち駒を青色背景でハイライト
  - リング効果（ring-2 ring-blue-400）で視覚的に強調
  - 手番に応じた選択状態の表示

## 技術的詳細

### 変更ファイル
1. **types/shogi.ts**
   - `CapturedPiecesProps`に`selectedPiece`プロパティを追加

2. **components/captured/CapturedPieces.tsx**
   - 選択中の持ち駒をハイライト表示
   - `isSelected`フラグによる条件付きスタイリング

3. **app/page.tsx**
   - 手番に応じて`selectedPiece`を適切にpropsとして渡す

## テスト結果

- ✅ 型チェック成功（`npx tsc --noEmit`）
- ✅ ビルド成功（`npm run build`）
- ✅ レスポンシブ対応確認済み

## DoD確認

- [x] 相手の駒がいるマスに移動すると駒を取れる
- [x] 取った駒が持ち駒エリアに表示される
- [x] 持ち駒は自分の駒として扱われる
- [x] UI上で持ち駒が確認できる
- [x] **選択中の持ち駒がハイライト表示される（追加）**
- [x] 型エラーなし、ビルド成功

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)