### PR TITLE
駒の成り機能を実装

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,15 +1,16 @@
-// 詳細: #6, #7, #18, エラーUI実装
+// 詳細: #6, #7, #13, #18, エラーUI実装
 'use client';
 
 import { Board } from '@/components/board/Board';
 import { CapturedPieces } from '@/components/captured/CapturedPieces';
 import { GameControl } from '@/components/control/GameControl';
 import { ErrorMessage } from '@/components/ui/ErrorMessage';
+import { PromotionDialog } from '@/components/game/PromotionDialog';
 import { GameProvider, useGame } from '@/lib/context/GameContext';
 import type { PieceType } from '@/types/shogi';
 
 function GameContent() {
-  const { gameState, newGame, resign, clearError, selectCapturedPiece } = useGame();
+  const { gameState, newGame, resign, clearError, selectCapturedPiece, promote, notPromote } = useGame();
 
   // 先手の持ち駒クリック処理（手番チェック付き）
   const handleBlackCapturedPieceClick = (pieceType: PieceType) => {
@@ -27,6 +28,15 @@ function GameContent() {
     <main className="min-h-screen bg-gradient-to-b from-amber-50 to-amber-100 py-4 sm:py-8">
       {/* エラーメッセージ表示 */}
       <ErrorMessage message={gameState.errorMessage} onClose={clearError} />
+
+      {/* 成り判定ダイアログ (#13) */}
+      <PromotionDialog
+        isOpen={gameState.promotionState.isOpen}
+        pieceType={gameState.promotionState.piece?.type || null}
+        player={gameState.promotionState.piece?.owner || null}
+        onPromote={promote}
+        onNotPromote={notPromote}
+      />
 
       <div className="container mx-auto px-4">
         {/* ヘッダー */}

--- a/lib/game/initial-state.ts
+++ b/lib/game/initial-state.ts
@@ -108,5 +108,11 @@ export function createInitialGameState(): GameState {
     selectedCapturedPiece: null, // #12: 持ち駒選択
     lastMove: null,
     errorMessage: null, // 詳細: エラーUI実装
+    promotionState: {  // #13: 成り判定ダイアログの状態
+      isOpen: false,
+      from: null,
+      to: null,
+      piece: null,
+    },
   };
 }

--- a/types/shogi.ts
+++ b/types/shogi.ts
@@ -147,6 +147,17 @@ export type GameStatus =
   | 'timeout';     // 時間切れ
 
 /**
+ * 成り判定ダイアログの状態
+ * 詳細: #13
+ */
+export type PromotionState = {
+  isOpen: boolean;
+  from: Position | null;
+  to: Position | null;
+  piece: Piece | null;
+};
+
+/**
  * ゲーム全体の状態
  */
 export type GameState = {
@@ -161,6 +172,7 @@ export type GameState = {
   selectedCapturedPiece: PieceType | null;  // #12: 選択中の持ち駒
   lastMove: Move | null;
   errorMessage: string | null;  // 詳細: エラーUI実装
+  promotionState: PromotionState;  // #13: 成り判定ダイアログの状態
 };
 
 // ========================================


### PR DESCRIPTION
## 📝 概要

Issue #13の駒の成り機能を実装しました。

## ✅ 実装内容

### 1. 成り判定ダイアログの状態管理
- `GameState`に`promotionState`を追加（types/shogi.ts）
- `PromotionState`型を定義（開閉状態、移動元/先、駒情報）

### 2. 成り判定ロジックの統合
- `GameContext`の`SELECT_SQUARE`アクションに成り判定を統合
- `shouldOfferPromotion()`で成りの選択肢を提示するか判定
- `mustPromote()`で強制成りを判定

### 3. 強制成りの実装
- 歩・香：最奥段で自動的に成る
- 桂：最奥2段で自動的に成る

### 4. 成り選択UIの追加
- `PromotionDialog`コンポーネントをページに統合
- 「成る」「成らない」ボタンで選択可能

### 5. アクション追加
- `PROMOTE`: 成りを選択
- `NOT_PROMOTE`: 成らないを選択

## 🧪 動作確認

- ✅ TypeScript型エラーなし（`npx tsc --noEmit`）
- ✅ ビルド成功（`npm run build`）
- ✅ 敵陣に駒が入ると成り選択ダイアログが表示される
- ✅ 強制成りの駒は自動的に成る
- ✅ 成駒の表示が正しく動作（既存の`getPieceName`関数を利用）

## 📂 変更ファイル

- `types/shogi.ts`: PromotionState型を追加
- `lib/game/initial-state.ts`: promotionStateの初期値を追加
- `lib/context/GameContext.tsx`: 成り判定ロジックとアクション追加
- `app/page.tsx`: PromotionDialogコンポーネント追加

Refs #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)