### PR TITLE
Hotfix: Move型ガードのフィールド名を修正 (#58)

### DIFF
--- a/lib/utils/type-guards.ts
+++ b/lib/utils/type-guards.ts
@@ -34,30 +34,48 @@ function isPlayer(value: unknown): value is Player {
 function isMove(value: unknown): value is Move {
   if (!isObject(value)) return false;
 
+  // type: 'move' | 'drop'
+  const hasValidType = value.type === 'move' || value.type === 'drop';
+
+  // from: Position | null (rank, fileを使用)
   const hasValidFrom =
     value.from === null ||
     (isObject(value.from) &&
-      typeof value.from.row === 'number' &&
-      typeof value.from.col === 'number');
+      typeof value.from.rank === 'number' &&
+      typeof value.from.file === 'number');
 
+  // to: Position (rank, fileを使用)
   const hasValidTo =
     isObject(value.to) &&
-    typeof value.to.row === 'number' &&
-    typeof value.to.col === 'number';
+    typeof value.to.rank === 'number' &&
+    typeof value.to.file === 'number';
 
-  const hasValidPiece = isObject(value.piece) && typeof value.piece.type === 'string';
+  // piece: PieceType (string)
+  const hasValidPiece = typeof value.piece === 'string';
 
-  const hasValidPlayer = isPlayer(value.player);
+  // isPromoted: boolean
+  const hasValidIsPromoted = typeof value.isPromoted === 'boolean';
 
-  const hasValidIsPromoted =
-    value.isPromoted === undefined || typeof value.isPromoted === 'boolean';
+  // shouldPromote: boolean
+  const hasValidShouldPromote = typeof value.shouldPromote === 'boolean';
+
+  // capturedPiece: PieceType | null
+  const hasValidCapturedPiece =
+    value.capturedPiece === null || typeof value.capturedPiece === 'string';
+
+  // timestamp: Date | string
+  const hasValidTimestamp =
+    value.timestamp instanceof Date || typeof value.timestamp === 'string';
 
   return (
+    hasValidType &&
     hasValidFrom &&
     hasValidTo &&
     hasValidPiece &&
-    hasValidPlayer &&
-    hasValidIsPromoted
+    hasValidIsPromoted &&
+    hasValidShouldPromote &&
+    hasValidCapturedPiece &&
+    hasValidTimestamp
   );
 }
 


### PR DESCRIPTION
## 🚨 Critical Hotfix

PR #59がマージされた後、Realtime動作テストで発見されたCritical Bugの修正。

---

## 🐛 問題

PR #59でマージされた型ガード関数 `isMove()` が、**間違ったフィールド名**をチェックしていたため、全てのmoveイベントが `Invalid move event payload` エラーになり、リアルタイム反映が動作しませんでした。

### エラーログ
```
Invalid move event payload: {move: {...}, player: 'black', ...}
```

### 根本原因
`lib/utils/type-guards.ts` の `isMove()` 関数が：
- ❌ `row` / `col` をチェック（間違い）
- ✅ `rank` / `file` が正解

---

## 🔧 修正内容

```typescript
// Before (間違い)
typeof value.from.row === 'number' &&
typeof value.from.col === 'number'

// After (正しい)
typeof value.from.rank === 'number' &&
typeof value.from.file === 'number'
```

### 完全な検証を追加
Move型の全フィールドを正しく検証：
- `type`: 'move' | 'drop'
- `from`: Position | null
- `to`: Position
- `piece`: PieceType (string)
- `isPromoted`: boolean
- `shouldPromote`: boolean
- `capturedPiece`: PieceType | null
- `timestamp`: Date | string

---

## ✅ 動作確認

### Before (エラー)
```
Invalid move event payload: {...}
（相手の手が反映されない）
```

### After (正常)
```
Sending move broadcast: {...}
Broadcast send result: ok
Received move: {player: 'white', playerId: '...'}
✅ リアルタイム反映成功
```

---

## 📊 影響範囲

- `lib/utils/type-guards.ts` のみ
- 既存の動作に影響なし（型ガードが正しく動作するようになる）

---

## 🧪 テスト

- ✅ `npm run type-check`: 型エラーなし
- ✅ 2つのブラウザウィンドウでリアルタイム対戦テスト成功
- ✅ エラーログなし

---

Refs #58