### PR TITLE
オンライン対戦時の盤面向き改善（後手視点で180度回転）#61

### DIFF
--- a/app/game/[gameId]/page.tsx
+++ b/app/game/[gameId]/page.tsx
@@ -146,6 +146,9 @@ function OnlineGameContent({ gameId }: { gameId: string }) {
     return isMyTurn ? `あなたの手番（${turnPlayerName}）` : `相手の手番（${turnPlayerName}）`;
   };
 
+  // 後手プレイヤーの場合は盤面を180度回転 (#61)
+  const isRotated = onlineInfo?.myPlayer === 'white';
+
   return (
     <main className="min-h-screen bg-gradient-to-br from-slate-50 via-slate-100 to-slate-200 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 py-3 sm:py-4 md:py-6 lg:py-8">
       {/* 接続状態インジケーター */}
@@ -233,30 +236,35 @@ function OnlineGameContent({ gameId }: { gameId: string }) {
         </div>
 
         {/* メインゲーム画面 */}
-        <div className="flex flex-col lg:flex-row items-center lg:items-start justify-center gap-4 sm:gap-5 md:gap-6 lg:gap-8 xl:gap-10">
-          {/* 後手の持ち駒 */}
-          <div className="w-full lg:w-auto order-1 lg:order-1">
-            <CapturedPieces
-              player="white"
-              pieces={gameState.captured.white}
-              selectedPiece={whiteSelectedPiece}
-              onPieceClick={handleWhiteCapturedPieceClick}
-            />
-          </div>
+        {/* 後手視点の場合は全体を180度回転 (#61) */}
+        <div className={isRotated ? 'rotate-180' : ''}>
+          <div className="flex flex-col lg:flex-row items-center lg:items-start justify-center gap-4 sm:gap-5 md:gap-6 lg:gap-8 xl:gap-10">
+            {/* 後手の持ち駒 */}
+            <div className="w-full lg:w-auto order-1 lg:order-1">
+              <CapturedPieces
+                player="white"
+                pieces={gameState.captured.white}
+                selectedPiece={whiteSelectedPiece}
+                onPieceClick={handleWhiteCapturedPieceClick}
+                isRotated={isRotated}
+              />
+            </div>
 
-          {/* 盤面 */}
-          <div className="order-2 lg:order-2">
-            <Board />
-          </div>
+            {/* 盤面（内部で二重回転処理） */}
+            <div className="order-2 lg:order-2">
+              <Board isRotated={isRotated} />
+            </div>
 
-          {/* 先手の持ち駒 */}
-          <div className="w-full lg:w-auto order-3 lg:order-3">
-            <CapturedPieces
-              player="black"
-              pieces={gameState.captured.black}
-              selectedPiece={blackSelectedPiece}
-              onPieceClick={handleBlackCapturedPieceClick}
-            />
+            {/* 先手の持ち駒 */}
+            <div className="w-full lg:w-auto order-3 lg:order-3">
+              <CapturedPieces
+                player="black"
+                pieces={gameState.captured.black}
+                selectedPiece={blackSelectedPiece}
+                onPieceClick={handleBlackCapturedPieceClick}
+                isRotated={isRotated}
+              />
+            </div>
           </div>
         </div>
 

--- a/components/board/Board.tsx
+++ b/components/board/Board.tsx
@@ -16,8 +16,9 @@ import type { Position } from '@/types/shogi';
  * 将棋盤コンポーネント
  * GameContextから状態を取得し、Squareコンポーネントを使って盤面を表示
  * 成り選択ダイアログはGameContextで一元管理 (#13, #18)
+ * @param isRotated - 後手視点で盤面を180度回転するか (#61)
  */
-export function Board() {
+export function Board({ isRotated = false }: { isRotated?: boolean }) {
   const {
     gameState,
     selectSquare: contextSelectSquare,
@@ -93,27 +94,27 @@ export function Board() {
   return (
     <>
       <div className="flex flex-col items-center gap-2 sm:gap-3 md:gap-4">
-        {/* 筋のラベル（横軸: 9-1） - モダンデザイン */}
+        {/* 筋のラベル（横軸: 9-1） - モダンデザイン + 回転対応 (#61) */}
         <div className="flex">
           <div className="w-6 sm:w-7 md:w-8 lg:w-9" /> {/* 段ラベル用のスペース */}
           {Array.from({ length: BOARD_SIZE }).map((_, file) => (
             <div
               key={file}
-              className="w-10 h-6 sm:w-11 sm:h-7 md:w-12 md:h-8 lg:w-13 lg:h-9 xl:w-14 xl:h-9 flex items-center justify-center text-xs sm:text-sm md:text-base font-semibold text-slate-600 dark:text-slate-400"
+              className={`w-10 h-6 sm:w-11 sm:h-7 md:w-12 md:h-8 lg:w-13 lg:h-9 xl:w-14 xl:h-9 flex items-center justify-center text-xs sm:text-sm md:text-base font-semibold text-slate-600 dark:text-slate-400 ${isRotated ? 'rotate-180' : ''}`}
             >
               {getFileLabel(file)}
             </div>
           ))}
         </div>
 
-        {/* 盤面本体 - モダンデザイン: 影とボーダーを追加 */}
+        {/* 盤面本体 - モダンデザイン: 影とボーダーを追加 + 回転対応 (#61) */}
         <div className="flex">
           {/* 段のラベル（縦軸: 一-九） */}
           <div className="flex flex-col">
             {Array.from({ length: BOARD_SIZE }).map((_, rank) => (
               <div
                 key={rank}
-                className="w-6 h-10 sm:w-7 sm:h-11 md:w-8 md:h-12 lg:w-9 lg:h-13 xl:w-9 xl:h-14 flex items-center justify-center text-xs sm:text-sm md:text-base font-semibold text-slate-600 dark:text-slate-400"
+                className={`w-6 h-10 sm:w-7 sm:h-11 md:w-8 md:h-12 lg:w-9 lg:h-13 xl:w-9 xl:h-14 flex items-center justify-center text-xs sm:text-sm md:text-base font-semibold text-slate-600 dark:text-slate-400 ${isRotated ? 'rotate-180' : ''}`}
               >
                 {getRankLabel(rank)}
               </div>
@@ -136,6 +137,7 @@ export function Board() {
                       isCheck={isSquareCheck(rank, file)}
                       isLastMove={isSquareLastMove(rank, file)}
                       onClick={() => handleSquareClick(position)}
+                      isRotated={isRotated}
                     />
                   );
                 })}

--- a/components/board/Square.tsx
+++ b/components/board/Square.tsx
@@ -25,7 +25,8 @@ export const Square = memo(function Square({
   isCheck,
   isLastMove,
   onClick,
-}: SquareProps) {
+  isRotated = false,
+}: SquareProps & { isRotated?: boolean }) {
   // 市松模様の背景色を決定（モダンカラー）
   const isEvenSquare = (position.rank + position.file) % 2 === 0;
   const baseColor = isEvenSquare ? 'bg-shogi-board-light' : 'bg-shogi-board-dark';
@@ -111,7 +112,8 @@ export const Square = memo(function Square({
         </div>
       )}
 
-      {/* 駒の表示 */}
+      {/* 駒の表示 (#61) */}
+      {/* Pieceコンポーネント内で既に後手の駒は回転しているため、ここでは追加の回転は不要 */}
       {piece && <Piece piece={piece} size="medium" isDraggable={false} />}
     </button>
   );

--- a/components/captured/CapturedPieces.tsx
+++ b/components/captured/CapturedPieces.tsx
@@ -12,11 +12,11 @@ import { PIECE_NAMES_JA } from '@/lib/game/constants';
 // 持ち駒として表示する駒の順序（玉は持ち駒にならない）
 const PIECE_ORDER = ['rook', 'bishop', 'gold', 'silver', 'knight', 'lance', 'pawn'] as const;
 
-export const CapturedPieces = memo(function CapturedPieces({ player, pieces, selectedPiece, onPieceClick }: CapturedPiecesProps) {
+export const CapturedPieces = memo(function CapturedPieces({ player, pieces, selectedPiece, onPieceClick, isRotated = false }: CapturedPiecesProps & { isRotated?: boolean }) {
   const hasCapturedPieces = PIECE_ORDER.some(pieceType => pieces[pieceType] > 0);
 
   return (
-    <div className="bg-white dark:bg-slate-800 rounded-xl shadow-medium p-3 sm:p-4 md:p-5 min-w-[180px] sm:min-w-[200px] md:min-w-[220px] lg:min-w-[240px] xl:min-w-[260px] border border-slate-200 dark:border-slate-700">
+    <div className={`bg-white dark:bg-slate-800 rounded-xl shadow-medium p-3 sm:p-4 md:p-5 min-w-[180px] sm:min-w-[200px] md:min-w-[220px] lg:min-w-[240px] xl:min-w-[260px] border border-slate-200 dark:border-slate-700 ${isRotated ? 'rotate-180' : ''}`}>
       {/* ヘッダー - モダンデザイン */}
       <h3 className="text-sm sm:text-base md:text-lg font-bold text-slate-800 dark:text-slate-100 mb-2 sm:mb-3 text-center border-b border-slate-200 dark:border-slate-700 pb-2">
         {player === 'black' ? '☗ 先手' : '☖ 後手'}


### PR DESCRIPTION
## 概要

後手プレイヤーには盤面全体を180度回転して表示し、自分の駒が常に手前に来るようにした。

## 変更内容

### 1. 盤面回転ロジック (#61)
- 後手プレイヤー視点では、メインゲーム画面全体を `rotate-180`
- 盤面ラベル（筋・段）を逆回転で正しい向きに
- 持ち駒カード全体を逆回転で正しい向きに
- 駒自体は回転させない（Pieceコンポーネント内で既に回転済み）

### 2. 修正ファイル
- `app/game/[gameId]/page.tsx`: メインゲーム画面の回転ロジック
- `components/board/Board.tsx`: ラベルの逆回転処理
- `components/board/Square.tsx`: isRotatedプロパティ追加（駒は回転させない）
- `components/captured/CapturedPieces.tsx`: カード全体の逆回転処理

### 3. UI/UX改善
- **先手視点**: 従来通り、自分の駒が下側に表示
- **後手視点**: 盤面全体が180度回転し、自分の駒が下側に表示
- 駒の向きは正しく保持（先手の駒は▽、後手の駒は△）
- 持ち駒も正しい向きで表示

## DoD確認

- [x] 後手プレイヤーの盤面が180度回転して表示される
- [x] 駒の向きが正しく表示される（先手の駒は▽、後手の駒は△）
- [x] 持ち駒表示が正しい向きで表示される
- [x] レスポンシブ対応（モバイル・タブレット・デスクトップ）
- [x] TypeScriptエラーなし（`tsc --noEmit`）
- [x] ビルドが通る（`npm run build`）
- [x] PR作成済み

## 次のステップ

パフォーマンス最適化は別Issue (#62) で対応予定。

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)